### PR TITLE
Added support for converting between IPA and Buckeye voiced bilabial fricatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 You should also add project tags for each release in Github, see [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
 
+# [Unreleased]
+
 # [1.1.2] - 11/13/2024
 ### Added
 - Support for the bilabial fricative mapping between Buckeye (BF) and IPA (β) 
+- Release creation instructions to CONTRIBUTIONS.md
 
 # [1.1.1] - 5/9/2024
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 You should also add project tags for each release in Github, see [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
 
+# [1.1.2] - 11/13/2024
+### Added
+- Support for the bilabial fricative mapping between Buckeye (BF) and IPA (β) 
+
 # [1.1.1] - 5/9/2024
 ### Added
 - Compatibility with older version of python back to 3.7

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -18,7 +18,6 @@ Issues that are open for contribution are given the following labels:
 - help-wanted
   - Issues with this tag are open for contribution and are suited for those with experience in contribution. 
 
-
 ## Issue reporting and help
 Report bugs or suggested features as issues on the [Github repo](https://github.com/ginic/phonecodes). Check to see whether your problem has already been reported before creating a new issue. Please keep in mind that we are a small team with many responsibilities and may take awhile to respond. 
 
@@ -49,3 +48,14 @@ To contribute to the project, do the following:
     - For example, "Fixed upload error to resolve Issue #987"
   - Include a short description of the changes you made
 
+## Creating a release
+For consistency, all version numbers for this project follow [semantic versioning](https://semver.org) with the format of integers A.B.C, where A is the “major” version, B is the “minor” version, and C is the “patch” version. Note that no version numbers should start with "v" anywhere, including on GitHub or in the CHANGELOG.md. 
+
+To create an official release, take the following steps:
+1. Decide what the new version number will be according to semantic versioning principles.
+2. Create a new branch from a commit that includes all the features and behavior that will be in the new version. On that branch, do the following:
+    - Update the CHANGELOG.md with a section for the new version number and its release date. In that section list included features under the appropriate "Added", "Changed", and "Removed" headers. 
+    - Update the project version number in pyproject.toml
+3. Create a pull request. Once the GitHub workflows for unit tests and publishing to TestPyPI pass, the pull request can be merged to the master branch. 
+4. Create an official release on GitHub following the [Creating a release instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository#creating-a-release) from the merge commit in the previous step. Name and tag the release with your version number. Copy contents of the version's CHANGELOG.md section to the Release's description. 
+5. Validate that the GitHub workflow for publishing to PyPI passes and that the new version appears on https://pypi.org/project/phonecodes/#history. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phonecodes"
-version = "1.1.1"
+version = "1.1.2"
 description = "Tools for loading dictionaries with various phonecodes (IPA, Callhome, X-SAMPA, ARPABET, DISC=CELEX, Buckeye), for converting among those phonecodes, and for searching those dictionaries for word sequences matching a target."
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/src/phonecodes/phonecode_tables.py
+++ b/src/phonecodes/phonecode_tables.py
@@ -601,6 +601,7 @@ _buckeye2ipa.update(
         "IHN": "ɪ̃",
         "ERN": "ɹ̩̃",
         "OYN": "ɔ̃ɪ̃",
+        "BF": "β",
     }
 )
 # Remove tone2ipa keys for Buckeye

--- a/test/test_phonecodes.py
+++ b/test/test_phonecodes.py
@@ -52,7 +52,7 @@ def test_convert_value_error():
         phonecodes.convert("DH IH S IH Z AH0 T EH1 S T", "arpabet", "buckeye")
 
 
-@pytest.mark.parametrize("ipa_str, buckeye_str", [("kæ̃n", "KAENN"), ("kæ̃n", "kaenn")])
+@pytest.mark.parametrize("ipa_str, buckeye_str", [("kæ̃n", "KAENN"), ("kæ̃n", "kaenn"), ("ʌpβoʊt", "AHPBFOWT")])
 def test_additional_buckeye_examples(ipa_str, buckeye_str):
     assert phonecodes.buckeye2ipa(buckeye_str) == ipa_str
     assert phonecodes.ipa2buckeye(ipa_str) == buckeye_str.upper()


### PR DESCRIPTION
This adds a mapping between Buckeye (BF) and IPA (β) which may be necessary if working with corrections for the Buckeye Corpus from from https://zenodo.org/records/4402237 and [Physical and phonological causes of coda /t/ glottalization in the mainstream American English of central Ohio. Sayfarth and Garellek. 2020.](https://www.journal-labphon.org/article/id/6282/)

I also added release instructions to CONTRIBUTIONS.md.