### PR TITLE
Updated sigstore github action version

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -77,7 +77,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ You should also add project tags for each release in Github, see [Managing relea
 - Support for the bilabial fricative mapping between Buckeye (BF) and IPA (β) 
 - Release creation instructions to CONTRIBUTIONS.md
 
+### Changed
+- Updated GitHub actions to latest 3.0.0 version of sigstore/gh-action-sigstore-python
+
 # [1.1.1] - 5/9/2024
 ### Added
 - Compatibility with older version of python back to 3.7


### PR DESCRIPTION
Fixes an error triggered by outdated sigstore GitHub Action during release creation