### PR TITLE
Fix TestPyPI failures

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -81,3 +81,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        skip-existing: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You should also add project tags for each release in Github, see [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
 
 # [Unreleased]
+### Fixed
+- TestPyPI GitHub workflow ignores existing release numbers, so job doesn't fail when version numbers are re-used
 
 # [1.1.4] - 11/14/2024
 ### Changed


### PR DESCRIPTION
Updated the TestPyPI workflow so it doesn't fail if the version number is re-used. That job runs on every PR, so it version numbers will be re-used frequently and that is expected.