### PR TITLE
Timit2ipa stops

### DIFF
--- a/.github/workflows/test_on_pull_request.yml
+++ b/.github/workflows/test_on_pull_request.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   test:
     name: Test package
-    runs-on: linux
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_on_pull_request.yml
+++ b/.github/workflows/test_on_pull_request.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
   push:
     branches: [ $default-branch ]
-    release: 
+    release:
       types: [published]
 
 
 jobs:
   test:
     name: Test package
-    runs-on: ubuntu-latest
+    runs-on: linux
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
@@ -27,7 +27,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install .[test]
-          
+
       - name: Test with pytest
         run: |
           pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You should also add project tags for each release in Github, see [Managing releases in a repository](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
 
 # [Unreleased]
+### Changed
+- Improved error messages about limited support for TIMIT
+
 ### Fixed
 - TestPyPI GitHub workflow ignores existing release numbers, so job doesn't fail when version numbers are re-used
+- Corrected handling of stop closure symbols in TIMIT and made TIMIT to IPA conversion more robust to variation in transcriptions of stop/affricates
 
 # [1.1.4] - 11/14/2024
 ### Changed
@@ -20,7 +24,7 @@ You should also add project tags for each release in Github, see [Managing relea
 
 # [1.1.2] - 11/13/2024
 ### Added
-- Support for the bilabial fricative mapping between Buckeye (BF) and IPA (β) 
+- Support for the bilabial fricative mapping between Buckeye (BF) and IPA (β)
 - Release creation instructions to CONTRIBUTIONS.md
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # phonecodes
-This library provides tools for converting between the [International Phonetic Alphabet (IPA)](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet) and other phonetic alphabets used to transcribe speech, including Callhome, [X-SAMPA](https://en.wikipedia.org/wiki/X-SAMPA), [ARPABET](https://en.wikipedia.org/wiki/ARPABET), [DISC/CELEX](https://catalog.ldc.upenn.edu/LDC96L14) and [Buckeye Corpus Phonetic Alphabet](https://buckeyecorpus.osu.edu/). Additionally, tools for searching mappings between phonetic symbols and reading/writing pronounciation lexicon files in several standard formats are also provided.
+This library provides tools for converting between the [International Phonetic Alphabet (IPA)](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet) and other phonetic alphabets used to transcribe speech, including Callhome, [X-SAMPA](https://en.wikipedia.org/wiki/X-SAMPA), [ARPABET](https://en.wikipedia.org/wiki/ARPABET), [DISC/CELEX](https://catalog.ldc.upenn.edu/LDC96L14), [Buckeye Corpus Phonetic Alphabet](https://buckeyecorpus.osu.edu/), and [TIMIT](https://catalog.ldc.upenn.edu/LDC93S1). Additionally, tools for searching mappings between phonetic symbols and reading/writing pronounciation lexicon files in several standard formats are also provided.
 
 These functionalities are useful for processing data for automatic speech recognition, text to speech, and linguistic analyses of speech.
 
@@ -14,7 +14,7 @@ If you want to convert to or from IPA to some other phonetic code, use `phonecod
 ```
 >>> from phonecodes import phonecodes
 >>> print(phonecodes.CODES) # available phonetic alphabets
-{'buckeye', 'disc', 'callhome', 'xsampa', 'arpabet', 'ipa'}
+{'arpabet', 'buckeye', 'ipa', 'timit', 'callhome', 'xsampa', 'disc'}
 >>> phonecodes.convert("DH IH S IH Z AH0 T EH1 S T", "arpabet", "ipa", "eng") # convert from IPA to ARPABET with language explicitly specified
 'ð ɪ s ɪ z ə t ˈɛ s t'
 >>> phonecodes.convert("ð ɪ s ɪ z ə t ˈɛ s t", "ipa", "arpabet") # convert from IPA to ARPABET with optional language left out
@@ -29,8 +29,9 @@ If you want to convert to or from IPA to some other phonetic code, use `phonecod
 'ð ɪ s ɪ z ə t ˈɛ s t'
 ```
 
-For 'arpabet', 'buckeye' and 'xsampa', specifying a language is optional and ignored by the code, since X-SAMPA is language agnostic and ARAPABET and Buckeye were designed to work only for English. 
-Note that for 'callhome' and 'disc' you should also specify a language code from the following lists:
+For 'arpabet', 'buckeye', 'timit' and 'xsampa', specifying a language is optional and ignored by the code, since X-SAMPA is language agnostic and ARAPABET, Buckeye, and TIMIT were designed to work only for English.
+
+For 'callhome' and 'disc' you should also specify a language code from the following lists:
 - DISC/CELEX: Dutch `'nld'`, English `'eng'`, German `'deu'`. Uses German if unspecified.
 - Callhome: Spanish `'spa'`, Egyptian Arabic `'arz'`, Mandarin Chinese `'cmn'`. You MUST specify an appropriate language code or you'll get a KeyError.
 
@@ -55,3 +56,5 @@ The supported corpus formats and their corresponding phonetic alphabets are as f
 | 'celex' | 'disc' | 'eng', 'ndl', 'deu' |
 | 'isle' | 'ipa' |  Not required |
 
+# Known Limitations
+- You cannot convert from IPA back t

--- a/README.md
+++ b/README.md
@@ -57,4 +57,4 @@ The supported corpus formats and their corresponding phonetic alphabets are as f
 | 'isle' | 'ipa' |  Not required |
 
 # Known Limitations
-- You cannot convert from IPA back t
+- You cannot convert to TIMIT format from IPA or any other phonecode, because TIMIT marks closures of stops with separate symbols. There are no symbols corresponding to these closures in other phonecodes and the closure is not predictable from the transcription alone.

--- a/src/phonecodes/phonecode_tables.py
+++ b/src/phonecodes/phonecode_tables.py
@@ -539,36 +539,56 @@ _ipa2tone = {symbol: {v: k for k, v in d.items()} for symbol, d in _tone2ipa.ite
 
 # TIMIT is written in a variant of ARPABET that includes a couple
 # of non-standard allophones, and most significantly, includes
-# separate symbols for the closure and release portions of each stop.
+# separate symbols for the closure and release portions of each stop and affricate.
+# Because the TIMIT corpus has separate symbols for closure and release,
+# but IPA only has one corresponding symbol, we need to map all
+# possibilities for inputs with and without spaces.
+# This words because the search algorithm is greedy and matches the longest
+# substrings with closure first if they are present.
 _timit2ipa = _arpabet2ipa.copy()
+_timit2ipa.pop("WH")
+_timit2ipa.pop("ER0")
+_timit2ipa.pop("IH0")
+_timit2ipa.pop("AH0")
 _timit2ipa.update(
     {
         "AX": "ə",
         "AX-H": "ə̥",
         "AXR": "ɚ",
-        "B": "",
         "BCL": "b",
-        "D": "",
+        "BCLB": "b",
+        "BCL B": "b",
         "DCL": "d",
+        "DCLD": "d",
+        "DCLJH": "dʒ",
+        "DCL D": "d",
+        "DCL JH": "dʒ",
         "DX": "ɾ",
         "ENG": "ŋ̍",
         "EPI": "",
-        "G": "",
         "GCL": "g",
+        "GCLG": "g",
+        "GCL G": "g",
         "HV": "ɦ",
         "H#": "",
         "IX": "ɨ",
         "KCL": "k",
-        "K": "",
+        "KCLK": "k",
+        "KCL K": "k",
         "NX": "ɾ̃",
-        "P": "",
         "PAU": "",
         "PCL": "p",
-        "T": "",
+        "PCLP": "p",
+        "PCL P": "p",
         "TCL": "t",
+        "TCLT": "t",
+        "TCLCH": "tʃ",
+        "TCL T": "t",
+        "TCL CH": "tʃ",
         "UX": "ʉ",
     }
 )
+
 
 # The Buckeye alphabet is a version of ARPABET used to transcribe the Ohio State Buckeye corpus.
 # The major differences are in nasalized vowels and some syllabic consonants

--- a/src/phonecodes/phonecodes.py
+++ b/src/phonecodes/phonecodes.py
@@ -1,6 +1,6 @@
 """
 A set of convenience functions for converting among different phone codes.
-Usage: 
+Usage:
 from phonecodes import phonecodes
 print phonecodes.CODES   # the known phone codes
 print phonecodes.LANGUAGES # the known languages
@@ -18,7 +18,7 @@ phonecodes.consonants
 """
 import phonecodes.phonecode_tables as phonecode_tables
 
-CODES = set(("ipa", "arpabet", "xsampa", "disc", "callhome", "buckeye"))
+CODES = set(("ipa", "arpabet", "xsampa", "disc", "callhome", "buckeye", "timit"))
 LANGUAGES = set(("eng", "deu", "nld", "arz", "cmn", "spa", "yue", "lao", "vie"))
 
 vowels = phonecode_tables._ipa_vowels
@@ -193,8 +193,14 @@ def timit2ipa(x, language=None):
     """Convert TIMIT phone codes to IPA"""
     x = x.upper()
     (il, ttf) = translate_string(x, phonecode_tables._timit2ipa)
-    ol = attach_tones_to_vowels(il, phonecode_tables._ipa_stressmarkers, phonecode_tables._ipa_vowels, -1, -1)
-    return "".join(ol)
+    return "".join(il)
+
+
+def ipa2timit(x, language=None):
+    raise ValueError(
+        "Converting to 'timit' is unsupported, because TIMIT closure symbols for stops"
+        " cannot be determined from text."
+    )
 
 
 def buckeye2ipa(x, language=None):
@@ -221,6 +227,7 @@ _convertfuncs = {
     "disc": (disc2ipa, ipa2disc),
     "callhome": (callhome2ipa, ipa2callhome),
     "buckeye": (buckeye2ipa, ipa2buckeye),
+    "timit": (timit2ipa, ipa2timit),
 }
 
 
@@ -253,7 +260,7 @@ def convert(s0, c0, c1, language=None):
     elif c0 != "ipa" and c1 == "ipa":
         return _convertfuncs[c0][0](s0, language)
     else:
-        raise ValueError(f"Must convert to/from ipa, not {c0} to {c1}")
+        raise ValueError(f"Must convert to/from 'ipa', not '{c0}' to '{c1}'")
 
 
 def convertlist(l0, c0, c1, language):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,6 +22,7 @@ def sentences():
         "eng_no_stress": {
             "ipa": "ð ɪ s ɪ z ə t ɛ s t",
             "buckeye": "DH IH S IH Z AX T EH S T",
+            "timit": "DH IH S IH Z AX TCL T EH S TCL T",
         },
         "amh": {
             "word": "ይህ ፈተና ነው",

--- a/test/test_phonecodes.py
+++ b/test/test_phonecodes.py
@@ -29,6 +29,7 @@ phonecode_cases = [
     # Buckeye conversion doesn't account for stress markers and language is ignored
     ("buckeye", "ipa", phonecodes.buckeye2ipa, "eng_no_stress"),
     ("ipa", "buckeye", phonecodes.ipa2buckeye, "eng_no_stress"),
+    ("timit", "ipa", phonecodes.timit2ipa, "eng_no_stress"),
 ]
 
 
@@ -47,12 +48,40 @@ def test_convert(in_code, out_code, fn_call, language, sentences):
     assert converted == expected
 
 
-def test_convert_value_error():
+@pytest.mark.parametrize(
+    "input_code, output_code",
+    [
+        ("arpabet", "buckeye"),
+        ("ipa", "timit"),
+    ],
+)
+def test_convert_value_error(input_code, output_code):
     with pytest.raises(ValueError):
-        phonecodes.convert("DH IH S IH Z AH0 T EH1 S T", "arpabet", "buckeye")
+        phonecodes.convert("DH IH S IH Z AH0 T EH1 S T", input_code, output_code)
 
 
 @pytest.mark.parametrize("ipa_str, buckeye_str", [("kæ̃n", "KAENN"), ("kæ̃n", "kaenn"), ("ʌpβoʊt", "AHPBFOWT")])
 def test_additional_buckeye_examples(ipa_str, buckeye_str):
     assert phonecodes.buckeye2ipa(buckeye_str) == ipa_str
     assert phonecodes.ipa2buckeye(ipa_str) == buckeye_str.upper()
+
+
+@pytest.mark.parametrize(
+    "ipa_str, timit_str",
+    [
+        (" tʃ ɑ k l ɨ t ", "h# ch aa kcl k l ix tcl t h#"),  # 'chocolate' with start/stop tokens and no initial closure
+        ("tʃ ɑ k l ɨ t", "tcl ch aa k l ix tcl t"),  # 'chocolate' with mixed closure inclusion
+        ("tʃ ɑ k l ɨ t", "tcl ch aa k l ix t"),  # 'chocolate' with mixed closure inclusion
+        ("tʃɑklɨt", "tclchaaklixtclt"),  # 'chocolate' with mixed closure inclusion, no spaces
+        ("tʃɑklɨt", "tclchaaklixt"),  # 'chocolate' with mixed closure inclusion, no spaces
+        ("dʒ oʊ k", "JH OW K"),  # 'joke' without closures
+        ("dʒ oʊ k", "DCL JH OW KCL K"),  # 'joke' with closures
+        (
+            "ɹ ɨ w ɔ ɹ ɾ ɪ d b aɪ b ɪ g t ɪ p s",
+            "R IX W AO R DX IH DCL B AY BCL B IH GCL T IH PCL P S",
+        ),  # 'rewarded by big tips'
+        ("bɪgtɪps", "bclbihgcltihpclps"),  # 'big tips' lower case no spaces
+    ],
+)
+def test_additional_timit_examples(ipa_str, timit_str):
+    assert phonecodes.timit2ipa(timit_str) == ipa_str

--- a/test/test_phonecodes.py
+++ b/test/test_phonecodes.py
@@ -82,6 +82,22 @@ def test_additional_buckeye_examples(ipa_str, buckeye_str):
         ),  # 'rewarded by big tips'
         ("bɪgtɪps", "bclbihgcltihpclps"),  # 'big tips' lower case no spaces
         ("bɪgtɪps", "bihgclgtcltihps"),  # 'big tips' lower case no spaces, flip closures
+        # 'This has been attributed to helium film flow in the vapor pressure thermometer.'
+        (
+            "ðɪs hɛz bɛn ɪtʃɪbʉɾɪd tʉ ɦɪliɨm fɪlm floʊ ən ðɨ veɪpə pɹɛʃɝ θəmɑmɨɾɚ",
+            "DHIHS HHEHZ BCLBEHN IHTCLCHIHBCLBUXDXIHDCL TUX HVIHLIYIXM FIHLM FLOW AXN DHIX VEYPCLPAX PCLPREHSHER THAXMAAMIXDXAXR",
+        ),
+        # 'About dawn he got up to blow.'
+        ("ə̥baʊtdɔnɦigɑɾʌptɨbloʊ", "AX-HBCLBAWTCLDAONHVIYGCLGAADXAHPCLTIXBCLBLOW"),
+        # 'As we ate, we talked.'
+        ("ʔæzwieɪtwitɔkt", "QAEZWIYEYTCLWIYTCLTAOKCLT"),
+        # 'The overweight charmer could slip poison into anyone's tea.'
+        # Note that the space is lost at the word boundary between 'overweight charmer'
+        # and 'slip poison'.
+        (
+            "ði oʊvɚweɪtʃɑɹmɚ kʊd slɪpɔɪzn̩ ɪntʔ ɛɾ̃iwənz ti",
+            "DHIY OWVAXRWEYTCL CHAARMAXR KCLKUHDCLD SLIHPCL POYZEN IHNTCLTQ EHNXIYWAXNZ TCLTIY",
+        ),
     ],
 )
 def test_additional_timit_examples(ipa_str, timit_str):

--- a/test/test_phonecodes.py
+++ b/test/test_phonecodes.py
@@ -81,6 +81,7 @@ def test_additional_buckeye_examples(ipa_str, buckeye_str):
             "R IX W AO R DX IH DCL B AY BCL B IH GCL T IH PCL P S",
         ),  # 'rewarded by big tips'
         ("bɪgtɪps", "bclbihgcltihpclps"),  # 'big tips' lower case no spaces
+        ("bɪgtɪps", "bihgclgtcltihps"),  # 'big tips' lower case no spaces, flip closures
     ],
 )
 def test_additional_timit_examples(ipa_str, timit_str):


### PR DESCRIPTION
- Corrected bug with bare stop symbols ("B", "P", "D", "T", "G", "K") being ignored in TIMIT to IPA conversions
- TIMIT to IPA conversion should be robust whether stop closure symbols are included or not in transcriptions of stops or affricates
- Added robustness and error handling for TIMIT to IPA conversions
- Added unit tests for TIMIT to IPA conversions focused on the stop closure problem