### PR TITLE
TIMIT symbol updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ You should also add project tags for each release in Github, see [Managing relea
 
 # [Unreleased]
 
+# [1.2.1] - 9/15/2025
+### Changed
+- Updated TIMIT conversions to IPA to use syllabic diacritics, mapping 'ER' to 'ɹ̩' and 'ENG' to 'ŋ̩'
+
 # [1.2.0] - 6/23/2025
 ### Changed
 - Improved error messages about limited support for TIMIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phonecodes"
-version = "1.2.0"
+version = "1.2.1"
 description = "Tools for loading dictionaries with various phonecodes (IPA, Callhome, X-SAMPA, ARPABET, DISC=CELEX, Buckeye), for converting among those phonecodes, and for searching those dictionaries for word sequences matching a target."
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/src/phonecodes/phonecode_tables.py
+++ b/src/phonecodes/phonecode_tables.py
@@ -1,6 +1,7 @@
 """
 Tables mapping other phonecodes to/from IPA
 """
+
 import re
 
 ###############################################################
@@ -564,7 +565,8 @@ _timit2ipa.update(
         "DCL D": "d",
         "DCL JH": "dʒ",
         "DX": "ɾ",
-        "ENG": "ŋ̍",
+        "ENG": "ŋ̩",
+        "ER": "ɹ̩",
         "EPI": "",
         "GCL": "g",
         "GCLG": "g",

--- a/test/test_phonecodes.py
+++ b/test/test_phonecodes.py
@@ -1,6 +1,7 @@
 """Load some pronlexes from the 'fixtures' subdirectory,
 test phone code conversion, and test both word and phone searches.
 """
+
 import phonecodes.phonecodes as phonecodes
 
 import pytest
@@ -69,7 +70,10 @@ def test_additional_buckeye_examples(ipa_str, buckeye_str):
 @pytest.mark.parametrize(
     "ipa_str, timit_str",
     [
-        (" tʃ ɑ k l ɨ t ", "h# ch aa kcl k l ix tcl t h#"),  # 'chocolate' with start/stop tokens and no initial closure
+        (
+            " tʃ ɑ k l ɨ t ",
+            "h# ch aa kcl k l ix tcl t h#",
+        ),  # 'chocolate' with start/stop tokens and no initial closure
         ("tʃ ɑ k l ɨ t", "tcl ch aa k l ix tcl t"),  # 'chocolate' with mixed closure inclusion
         ("tʃ ɑ k l ɨ t", "tcl ch aa k l ix t"),  # 'chocolate' with mixed closure inclusion
         ("tʃɑklɨt", "tclchaaklixtclt"),  # 'chocolate' with mixed closure inclusion, no spaces
@@ -84,7 +88,7 @@ def test_additional_buckeye_examples(ipa_str, buckeye_str):
         ("bɪgtɪps", "bihgclgtcltihps"),  # 'big tips' lower case no spaces, flip closures
         # 'This has been attributed to helium film flow in the vapor pressure thermometer.'
         (
-            "ðɪs hɛz bɛn ɪtʃɪbʉɾɪd tʉ ɦɪliɨm fɪlm floʊ ən ðɨ veɪpə pɹɛʃɝ θəmɑmɨɾɚ",
+            "ðɪs hɛz bɛn ɪtʃɪbʉɾɪd tʉ ɦɪliɨm fɪlm floʊ ən ðɨ veɪpə pɹɛʃɹ̩ θəmɑmɨɾɚ",
             "DHIHS HHEHZ BCLBEHN IHTCLCHIHBCLBUXDXIHDCL TUX HVIHLIYIXM FIHLM FLOW AXN DHIX VEYPCLPAX PCLPREHSHER THAXMAAMIXDXAXR",
         ),
         # 'About dawn he got up to blow.'


### PR DESCRIPTION
- Updated TIMIT conversions to IPA to use syllabic diacritics, mapping 'ER' to 'ɹ̩' and 'ENG' to 'ŋ̩'